### PR TITLE
Adiciona slack criado por Michael Lopp

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Tem algum conteúdo interessante em português? [Nos ajude](contributing.md) a t
 | Comunidade 	| 🇺🇸 | [Software Lead Weekly Slack Community](https://swlw.slack.com/) | Oren Ellenbogen
 | Comunidade 	| 🇺🇸 | [Engineering Managers Slack Community](https://engmanagers.github.io/) | -
 | Post | 🇧🇷 | [Liderança técnica: quando, como e por quê?](https://medium.com/@danielaarajo/parte-1-lideran%C3%A7a-t%C3%A9cnica-quando-como-e-por-qu%C3%AA-430ea0bc5cba) | Daniela Araújo
+| Comunidade | 🇺🇸 | [Rands Leadership Slack](https://randsinrepose.com/welcome-to-rands-leadership-slack/) | Michael Lopp |
 
 
 ### Saúde do time e processos


### PR DESCRIPTION
## Descrição do PR
Adiciona uma comunidade no slack

## Por que esse conteúdo é relevante?
Essa comunidade no slack é bem ativa e com conteúdo relevante, diversos lideres da área da tecnologia estão nele e compartilham sobre experiências e tiram dúvidas sobre o dia a dia. O slack é bem organizado com canais e é possível aprender bastante por lá.

## Checklist
- [x] Li todos os requisitos de [contribuição]()
- [x] Já procurei esse conteúdo/tópico na lista e não o encontrei
- [x] Procurei se existe o conteúdo em português primeiro
- [ ] Adicionei a label referente ao meu tipo de PR
- [x] Estou de acordo com o [código de conduta]()
