### PR TITLE
Add livro Staff Engineer na seção de Gestão

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Tem algum conteúdo interessante em português? [Nos ajude](contributing.md) a t
 | Podcast | 🇺🇸 | [Programming Leadership](https://marcusblankenship.com/category/podcast/) | Marcus Blankenship |
 | Podcast | 🇧🇷 | [Tech Leadership Rocks](https://techleadership.rocks) | Tech Leadership Rocks |
 | Newsletter | 🇺🇸 | [Harvard Business Review Leadership](https://hbr.org/topic/leadership) | - |
+| Livro | 🇺🇸 | [Staff Engineer: Leadership beyond the management track](https://staffeng.com/book) | Will Larson |
 
 
 ### Saúde do time e processos


### PR DESCRIPTION
## Descrição do PR

Adiciona o livro "Staff Engineer: Leadership beyond the management track" na seção de Gestão.

## Por que esse conteúdo é relevante?

É um livro muito recente, foi publicado em 2021, e é um dos poucos a focar no papel do Staff Engineer. O autor traz uma definição do papel de Staff Engineer, bem como vários cenários reais de engenheiros de grandes empresas como Dropbox, Stripe, Slack, dentre outras. Ainda, dá dicas de como alcançar este nível e o que é esperado de uma pessoa nessa posição. É um livro excelente para aqueles que querem seguir pela carreira mais técnica e até para aqueles que já estão atuando neste papel.

## Checklist
- [x] Li todos os requisitos de [contribuição]()
- [x] Já procurei esse conteúdo/tópico na lista e não o encontrei
- [x] Procurei se existe o conteúdo em português primeiro
- [ ] Adicionei a label referente ao meu tipo de PR
- [x] Estou de acordo com o [código de conduta]()
